### PR TITLE
Clear billboardOrientationBuffer on map cleanup

### DIFF
--- a/Ambermoon.Renderer.OpenGL/RenderBuffer.cs
+++ b/Ambermoon.Renderer.OpenGL/RenderBuffer.cs
@@ -890,6 +890,14 @@ namespace Ambermoon.Renderer
                 textureEndCoordBuffer.Remove(index + 3);
             }
 
+            if (billboardOrientationBuffer != null)
+            {
+                billboardOrientationBuffer.Remove(index);
+                billboardOrientationBuffer.Remove(index + 1);
+                billboardOrientationBuffer.Remove(index + 2);
+                billboardOrientationBuffer.Remove(index + 3);
+            }
+            
             // TODO: this code causes problems. commented out for now
             /*if (newSize != -1)
             {


### PR DESCRIPTION
The buffer needs to be cleaned up, or else we get an exception when loading a second 3D map