### PR TITLE
Clean up CollisionBodies on map change to prevent Exception

### DIFF
--- a/Ambermoon.Core/Render/RenderMap3D.cs
+++ b/Ambermoon.Core/Render/RenderMap3D.cs
@@ -100,9 +100,11 @@ namespace Ambermoon.Render
             floor = null;
             ceiling = null;
 
+            blockCollisionBodies.Values.ToList().ForEach(bodies => bodies.ForEach(body => body = null));
             walls.Values.ToList().ForEach(walls => walls.ForEach(wall => wall?.Delete()));
             objects.Values.ToList().ForEach(objects => objects.ForEach(obj => obj?.Delete()));
 
+            blockCollisionBodies.Clear();
             walls.Clear();
             objects.Clear();
         }

--- a/Ambermoon.Core/Render/RenderMap3D.cs
+++ b/Ambermoon.Core/Render/RenderMap3D.cs
@@ -100,13 +100,13 @@ namespace Ambermoon.Render
             floor = null;
             ceiling = null;
 
-            blockCollisionBodies.Values.ToList().ForEach(bodies => bodies.ForEach(body => body = null));
             walls.Values.ToList().ForEach(walls => walls.ForEach(wall => wall?.Delete()));
             objects.Values.ToList().ForEach(objects => objects.ForEach(obj => obj?.Delete()));
 
-            blockCollisionBodies.Clear();
             walls.Clear();
             objects.Clear();
+
+            blockCollisionBodies.Clear();
         }
 
         void EnsureLabBackgroundGraphics(IGraphicProvider graphicProvider)


### PR DESCRIPTION
When entering a second 3D map (i.e. Spannenberg after Großvaters Keller), I get the following exception:
```
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: 32
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Ambermoon.Render.RenderMap3D.AddWall(ISurface3DFactory surfaceFactory, IRenderLayer layer, UInt32 mapX, UInt32 mapY, UInt32 wallIndex) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\RenderMap3D.cs:line 265
   at Ambermoon.Render.RenderMap3D.UpdateSurfaces() in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\RenderMap3D.cs:line 406
   at Ambermoon.Render.RenderMap3D.SetMap(Map map, UInt32 playerX, UInt32 playerY, CharacterDirection playerDirection) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\RenderMap3D.cs:line 86
   at Ambermoon.Game.Start3D(Map map, UInt32 playerX, UInt32 playerY, CharacterDirection direction) in K:\GIT\Ambermoon.net\Ambermoon.Core\Game.cs:line 245
   at Ambermoon.Render.Character2D.MoveTo(Map map, UInt32 x, UInt32 y, UInt32 ticks, Boolean frameReset, Nullable`1 newDirection) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\Character2D.cs:line 89
   at Ambermoon.Render.Player2D.MoveTo(Map map, UInt32 x, UInt32 y, UInt32 ticks, Boolean frameReset, Nullable`1 newDirection) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\Player2D.cs:line 188
   at Ambermoon.Game.Teleport(MapChangeEvent mapChangeEvent) in K:\GIT\Ambermoon.net\Ambermoon.Core\Game.cs:line 867
   at Ambermoon.MapExtensions.ExecuteEvent(Map map, Game game, IRenderPlayer player, MapEventTrigger trigger, UInt32 x, UInt32 y, IMapManager mapManager, UInt32 ticks, MapEvent mapEvent, Boolean& lastEventStatus) in K:\GIT\Ambermoon.net\Ambermoon.Core\MapExtensions.cs:line 35
   at Ambermoon.MapExtensions.TriggerEvents(Map map, Game game, IRenderPlayer player, MapEventTrigger trigger, UInt32 x, UInt32 y, IMapManager mapManager, UInt32 ticks) in K:\GIT\Ambermoon.net\Ambermoon.Core\MapExtensions.cs:line 150
   at Ambermoon.Render.RenderMap2D.TriggerEvents(IRenderPlayer player, MapEventTrigger trigger, UInt32 x, UInt32 y, IMapManager mapManager, UInt32 ticks) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\RenderMap2D.cs:line 120
   at Ambermoon.Render.Player2D.Move(Int32 x, Int32 y, UInt32 ticks, Nullable`1 prevDirection, Boolean updateDirectionIfNotMoving) in K:\GIT\Ambermoon.net\Ambermoon.Core\Render\Player2D.cs:line 125
   at Ambermoon.Game.Move2D(Int32 x, Int32 y) in K:\GIT\Ambermoon.net\Ambermoon.Core\Game.cs:line 410
   at Ambermoon.Game.Move() in K:\GIT\Ambermoon.net\Ambermoon.Core\Game.cs:line 457
   at Ambermoon.Game.Update(Double deltaTime) in K:\GIT\Ambermoon.net\Ambermoon.Core\Game.cs:line 174
   at Ambermoon.GameWindow.Window_Update(Double delta) in K:\GIT\Ambermoon.net\Ambermoon.net\GameWindow.cs:line 235
   at Silk.NET.Windowing.Desktop.GlfwWindow.RaiseUpdateFrame()
   at Silk.NET.Windowing.Desktop.GlfwWindow.DoUpdate()
   at Silk.NET.Windowing.Common.WindowExtensions.<>c__DisplayClass2_0.<Run>b__0()
   at Silk.NET.Windowing.Desktop.GlfwWindow.Run(Action onFrame)
   at Silk.NET.Windowing.Common.WindowExtensions.Run(IView view)
   at Ambermoon.GameWindow.Run(Configuration configuration) in K:\GIT\Ambermoon.net\Ambermoon.net\GameWindow.cs:line 258
   at Ambermoon.Program.Main() in K:\GIT\Ambermoon.net\Ambermoon.net\Program.cs:line 16

```
I hope the first line of the fix is okay. The ICollisionBody interface doesn't have a Delete() method.
