### PR TITLE
Delete hovered item on resetting the layout

### DIFF
--- a/Ambermoon.Core/UI/ItemGrid.cs
+++ b/Ambermoon.Core/UI/ItemGrid.cs
@@ -32,6 +32,9 @@ namespace Ambermoon.UI
         {
             for (int i = 0; i < items.Length; ++i)
                 SetItem(i, null);
+
+            hoveredItemName?.Delete();
+            hoveredItemName = null;
         }
 
         public void SetItem(int slot, ItemSlot item)


### PR DESCRIPTION
If you leave a chest window or the inventory while hovering over an item, the name is not deleted.

![grafik](https://user-images.githubusercontent.com/12674912/91667101-637fc000-eb02-11ea-91d4-02a8199ba187.png)
