### PR TITLE
Fixed creation of shadow sprites

### DIFF
--- a/Ambermoon.Renderer.OpenGL/RenderText.cs
+++ b/Ambermoon.Renderer.OpenGL/RenderText.cs
@@ -307,26 +307,26 @@ namespace Ambermoon.Renderer
                 };
 
                 characterSprites.Add(sprite);
+            }
 
-                if (Shadow)
+            if (Shadow)
+            {
+                foreach (var characterSprite in characterSprites)
                 {
-                    foreach (var characterSprite in characterSprites)
+                    var shadowSprite = new TextCharacterSprite(CharacterWidth, CharacterHeight,
+                        characterSprite.TextureAtlasOffset.X, characterSprite.TextureAtlasOffset.Y,
+                        virtualScreen)
                     {
-                        var shadowSprite = new TextCharacterSprite(CharacterWidth, CharacterHeight,
-                            characterSprite.TextureAtlasOffset.X, characterSprite.TextureAtlasOffset.Y,
-                            virtualScreen)
-                        {
-                            TextColorIndex = ShadowColorIndex,
-                            X = characterSprite.X + 1,
-                            Y = characterSprite.Y + 1,
-                            Layer = Layer,
-                            PaletteIndex = 50,
-                            Visible = Visible,
-                            DisplayLayer = DisplayLayer
-                        };
+                        TextColorIndex = ShadowColorIndex,
+                        X = characterSprite.X + 1,
+                        Y = characterSprite.Y + 1,
+                        Layer = Layer,
+                        PaletteIndex = 50,
+                        Visible = Visible,
+                        DisplayLayer = DisplayLayer
+                    };
 
-                        characterShadowSprites.Add(shadowSprite);
-                    }
+                    characterShadowSprites.Add(shadowSprite);
                 }
             }
         }


### PR DESCRIPTION
The shadows for the text characters are currently created per character due to a bracket at the wrong position.
I have a fix for it. :-)

=> Hovering over items with longer names is now much faster!
