### PR TITLE
Upgraded to .NET 7.0

### DIFF
--- a/Ambermoon.Audio.Android/Ambermoon.Audio.Android.csproj
+++ b/Ambermoon.Audio.Android/Ambermoon.Audio.Android.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-android30.0</TargetFramework>
-	<SupportedOSPlatformVersion>30</SupportedOSPlatformVersion>
+    <TargetFramework>net7.0-android30.0</TargetFramework>
+	  <SupportedOSPlatformVersion>30</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;DebugAndroid;ReleaseWithAndroid</Configurations>

--- a/Ambermoon.ConcatFiles/Ambermoon.ConcatFiles.csproj
+++ b/Ambermoon.ConcatFiles/Ambermoon.ConcatFiles.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <Copyright>Copyright (C) 2021 by Robert Schneckenhaus</Copyright>
     <Company>Robert Schneckenhaus</Company>

--- a/Ambermoon.Data.FileSystems/Ambermoon.Data.FileSystems.csproj
+++ b/Ambermoon.Data.FileSystems/Ambermoon.Data.FileSystems.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
 	<Authors>Robert Schneckenhaus</Authors>
 	<Description>Library that provides file system abstraction for Ambermoon.</Description>

--- a/Ambermoon.Data.Legacy/Ambermoon.Data.Legacy.csproj
+++ b/Ambermoon.Data.Legacy/Ambermoon.Data.Legacy.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-	<Nullable>disable</Nullable>
+    <TargetFramework>net7.0</TargetFramework>
+	  <Nullable>disable</Nullable>
     <Authors>Robert Schneckenhaus</Authors>
     <Description>Library to load and process legacy data from the Amiga game Ambermoon.</Description>
     <PackageProjectUrl>https://github.com/Pyrdacor/Ambermoon.net</PackageProjectUrl>

--- a/Ambermoon.Data.Pyrdacor/Ambermoon.Data.Pyrdacor.csproj
+++ b/Ambermoon.Data.Pyrdacor/Ambermoon.Data.Pyrdacor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Ambermoon.PrepareIcons/Ambermoon.PrepareIcons.csproj
+++ b/Ambermoon.PrepareIcons/Ambermoon.PrepareIcons.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Robert Schneckenhaus</Authors>
     <Copyright>Copyright (C) 2021 by Robert Schneckenhaus</Copyright>

--- a/Ambermoon.net/Ambermoon.net.csproj
+++ b/Ambermoon.net/Ambermoon.net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Ambermoon</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <Version>1.8.1</Version>

--- a/AmbermoonAdditionalDataLoader/AmbermoonAdditionalDataLoader.csproj
+++ b/AmbermoonAdditionalDataLoader/AmbermoonAdditionalDataLoader.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-	<Version>10.8.0</Version>
+    <TargetFramework>net7.0</TargetFramework>
+	  <Version>10.8.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AmbermoonAndroid/AmbermoonAndroid.csproj
+++ b/AmbermoonAndroid/AmbermoonAndroid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFramework>net7.0-android</TargetFramework>
     <SupportedOSPlatformVersion>29.0</SupportedOSPlatformVersion>
 	<RuntimeIdentifiers>android.29-x64;android.29-arm;android.30-x64;android.30-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>

--- a/AmbermoonPatcher/AmbermoonPatcher.csproj
+++ b/AmbermoonPatcher/AmbermoonPatcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 	<RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/build-arm64.sh
+++ b/build-arm64.sh
@@ -1,9 +1,9 @@
 mkdir publish-arm64
 copy versions.dat publish-arm64
-dotnet publish -c Debug ./Ambermoon.ConcatFiles/Ambermoon.ConcatFiles.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true  -r linux-x64 --nologo --self-contained -o ./publish-arm64
+dotnet publish -c Debug ./Ambermoon.ConcatFiles/Ambermoon.ConcatFiles.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true  -r linux-arm64 --nologo --self-contained -o ./publish-arm64
 dotnet publish -c Debug ./Ambermoon.net/Ambermoon.net.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true  -r linux-arm64 --nologo --self-contained -o ./publish-arm64
 dotnet publish -c Debug ./AmbermoonPatcher/AmbermoonPatcher.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true  -r linux-arm64 --nologo --self-contained -o ./publish-arm64
-cd publish-v
-Ambermoon.ConcatFiles versions versions.dat patcher AmbermoonPatcher Ambermoon.net
+cd publish-arm64
+./Ambermoon.ConcatFiles versions versions.dat patcher AmbermoonPatcher Ambermoon.net
 rm ./versions.dat
 rm ./Ambermoon.ConcatFiles


### PR DESCRIPTION
Just a simple change, to upgrade all projects to .NET 7.0.
Most were targeting .NET 6, one was still targeting .Net Core 3.1 (any reason why?). The Android projects might need to go a bit higher, from 30 to 33, but I've left those for now (just changed them to `net7.0-android30.0`).

I noticed you already have scripts to build releases for Linux-ARM64, but you don't have a release out for that platform yet. It would be cool to have a Raspberry Pi version for this ;-) And perhaps even automated builds, if you want. I can contribute with another PR about that, if you're interested.