### PR TITLE
Fix macOS Save and Config Pathing.

### DIFF
--- a/Ambermoon.net/Configuration.cs
+++ b/Ambermoon.net/Configuration.cs
@@ -305,7 +305,7 @@ namespace Ambermoon
                     return bundleDirectory;
 
                 if (OperatingSystem.IsMacOSVersionAtLeast(12) || new DirectoryInfo(bundleDirectory).Attributes.HasFlag(FileAttributes.ReadOnly))
-                    bundleDirectory = "~/Library/Application Support/Ambermoon.net";
+                    bundleDirectory = "/Library/Application Support/Ambermoon.net";
 
                 return bundleDirectory;
             }


### PR DESCRIPTION
Resolves https://github.com/Pyrdacor/Ambermoon.net/issues/390.

Seems like relative pathing doesn't work w/o perhaps some complex concatenation that would be beyond by C# skill level. :/

But, it turns out, macOS automatically redirects writes to /Library/Application Support/ to ~/Library/Application Support/ unless the user is elevated, in which case this is normal behavior as programs installed for all users and that regularly run with elevation write to /Library/Application Support/.

I think this is a solid fix that conforms to all the expected behavior on the macOS platform. Thanks!
