### PR TITLE
Additions and Fixes for building on macOS.

### DIFF
--- a/Ambermoon.net/Ambermoon.net.csproj
+++ b/Ambermoon.net/Ambermoon.net.csproj
@@ -18,6 +18,7 @@
     <ApplicationIcon>app.ico</ApplicationIcon>
     <Configurations>Debug;Release;DebugAndroid;ReleaseAndroid;ReleaseNative;DebugES;ReleaseES</Configurations>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
 	<!--<PublishAot>true</PublishAot>
 	<TrimMode>full</TrimMode>
 	<PublishTrimmed>true</PublishTrimmed>

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -1,0 +1,18 @@
+dotnet publish -c Release ./Ambermoon.net/Ambermoon.net.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -r osx-x64 --no-restore --self-contained
+dotnet publish -c Release ./Ambermoon.net/Ambermoon.net.csproj -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -r osx-arm64 --no-restore --self-contained
+dotnet publish -c Release ./Ambermoon.ConcatFiles/Ambermoon.ConcatFiles.csproj -r osx-x64 --no-restore
+sudo xcode-select -p
+sudo xcode-select -s /Applications/Xcode.app
+mkdir -p ./bundle/Ambermoon.net/Ambermoon.net.app/Contents/MacOS/
+cp -r ./Ambermoon.net/Mac/* ./bundle/Ambermoon.net/
+cp "./Ambermoon.net/bin/Release/net8.0/osx-x64/publish/Ambermoon.net" ./bundle/Ambermoon.net/Ambermoon.net.app/Contents/MacOS/Ambermoon.net
+cp "./Ambermoon.net/versions.dat" ./bundle/Ambermoon.net/Ambermoon.net.app/Contents/Resources/
+cp "./Ambermoon.net/diffs.dat" ./bundle/Ambermoon.net/Ambermoon.net.app/Contents/Resources/
+cp -r ./Package/* ./bundle/Ambermoon.net/
+codesign -s - --force --verbose --deep --no-strict ./bundle/Ambermoon.net/Ambermoon.net.app
+7z a Ambermoon.net-Mac.zip ./bundle/Ambermoon.net/ -mx9
+cp -r ./bundle ./bundle-arm
+rm ./bundle-arm/Ambermoon.net/Ambermoon.net.app/Contents/MacOS/Ambermoon.net
+cp "./Ambermoon.net/bin/Release/net8.0/osx-arm64/publish/Ambermoon.net" ./bundle-arm/Ambermoon.net/Ambermoon.net.app/Contents/MacOS/Ambermoon.net
+codesign -s - --force --verbose --deep --no-strict ./bundle-arm/Ambermoon.net/Ambermoon.net.app
+7z a Ambermoon.net-Mac-ARM.zip ./bundle-arm/Ambermoon.net/ -mx9


### PR DESCRIPTION
These are the additions and fixes I made to enable and streamline building Ambermoon.net on macOS while testing fixes for https://github.com/Pyrdacor/Ambermoon.net/issues/390.

I use an M1 MacBook Air running macOS Sequoia 15.3.1. My build system uses homebrew.

With this PR, the build process is as follows:

1. git clone --recursive https://github.com/Pyrdacor/Ambermoon.net
2. cd Ambermoon.net
3. dotnet publish -f net8.0
4. ./build-macos.sh

You should now have ARM and x64 macOS builds made and zipped! :D

Thanks!