### PR TITLE
Add the Orc Plague quest

### DIFF
--- a/Ambermoon.Core/UI/QuestCustomVariables.cs
+++ b/Ambermoon.Core/UI/QuestCustomVariables.cs
@@ -89,6 +89,7 @@ partial class QuestLog
     const uint GlobalVar_TolimarQuestStarted = 8191u;
     const uint GlobalVar_SylphQuestStarted = 8190u;
     const uint GlobalVar_ShowedAmberToGrandfather = 8189u;
+    const uint GlobalVar_GaveOrcLeaderHeadToBaronGeorge = 8188u;
 
     private readonly List<CustomGlobalVariableEvent> customGlobalVariableEvents = [];
 
@@ -108,5 +109,10 @@ partial class QuestLog
         customGlobalVariableEvents.Add(new CustomGlobalVariableNPCEvent(this, game,
             (npc, @event) => npc.Index == 1 && @event is ConversationEvent c && (c.Interaction == ConversationEvent.InteractionType.ShowItem || c.Interaction == ConversationEvent.InteractionType.GiveItem) && c.ItemIndex == 209,
             GlobalVar_ShowedAmberToGrandfather));
+
+        // Give the orc leader's head to Baron George (Freiherr Georg, NPC 8) -- completes the Orc Plague quest.
+        customGlobalVariableEvents.Add(new CustomGlobalVariableNPCEvent(this, game,
+            (npc, @event) => npc.Index == 8 && @event is ConversationEvent c && c.Interaction == ConversationEvent.InteractionType.GiveItem && c.ItemIndex == 268,
+            GlobalVar_GaveOrcLeaderHeadToBaronGeorge));
     }
 }

--- a/Ambermoon.Core/UI/QuestTexts.cs
+++ b/Ambermoon.Core/UI/QuestTexts.cs
@@ -202,7 +202,7 @@ internal static class QuestTexts
             { SubQuestType.Sylphs_RescueSelena, "Rescue Selena" },
             // Orcs
             { SubQuestType.OrcPlague_DefeatTheOrcLeader, "Defeat the orc leader" },
-            { SubQuestType.OrcPlague_ReturnToGeorg, "Bring the proof to Freiherr Georg" },
+            { SubQuestType.OrcPlague_ReturnToGeorg, "Bring the proof to Baron George" },
             // TODO ...
         } }
         // TODO ...

--- a/Ambermoon.Core/UI/QuestTexts.cs
+++ b/Ambermoon.Core/UI/QuestTexts.cs
@@ -149,6 +149,9 @@ internal static class QuestTexts
             { SubQuestType.Sylphs_FindTheHiddenItemInTheTree, "Finde den Gegenstand im Baum" },
             { SubQuestType.Sylphs_FindTheSylphs, "Finde die Feen" },
             { SubQuestType.Sylphs_RescueSelena, "Rette Selena" },
+            // Orcs
+            { SubQuestType.OrcPlague_DefeatTheOrcLeader, "Besiege den Anführer der Orks" },
+            { SubQuestType.OrcPlague_ReturnToGeorg, "Bring den Beweis zu Freiherr Georg" },
             // TODO ...
         } },
         { GameLanguage.English, new()
@@ -197,6 +200,9 @@ internal static class QuestTexts
             { SubQuestType.Sylphs_FindTheHiddenItemInTheTree, "Find the item in the tree" },
             { SubQuestType.Sylphs_FindTheSylphs, "Find the fairies" },
             { SubQuestType.Sylphs_RescueSelena, "Rescue Selena" },
+            // Orcs
+            { SubQuestType.OrcPlague_DefeatTheOrcLeader, "Defeat the orc leader" },
+            { SubQuestType.OrcPlague_ReturnToGeorg, "Bring the proof to Freiherr Georg" },
             // TODO ...
         } }
         // TODO ...

--- a/Ambermoon.Core/UI/Quests.cs
+++ b/Ambermoon.Core/UI/Quests.cs
@@ -90,6 +90,8 @@ public enum SubQuestType
     GoldenHorseshoes_FindHorseshoes,
     GoldenHorseshoes_ReturnHorseshoes,
     // Orcs
+    OrcPlague_DefeatTheOrcLeader, // Freiherr Georg teaches keyword "Probleme"; defeat the hill-giant orc leader in the Orc Cave (map 280)
+    OrcPlague_ReturnToGeorg,
     // Sandra's Daughter
     SandrasDaughter_GoToBurnvilleAndFindSabine, // after talking to sandra
     SandrasDaughter_RescueSabine, // after finding sabine's note
@@ -253,6 +255,34 @@ file class GlobalVariableTrigger(Game game, TriggerType triggerType, uint index,
             return true;
         }
         else if (game.CurrentSavegame.GetGlobalVariable(index) == expectedValue)
+        {
+            subQuest.State = NewState;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+// Fires when the party hands a specific item to an NPC during a conversation (a "GiveItem" interaction).
+// Used for "return the proof to the quest giver" steps that the original game does NOT track with a global variable.
+file class ItemGivenToNpcTrigger(TriggerType triggerType, uint itemIndex) : IQuestTrigger
+{
+    public QuestState OldState => triggerType.GetOldState();
+    public QuestState NewState => triggerType.GetNewState();
+
+    bool IQuestTrigger.CheckEvent(Event @event, SubQuest subQuest)
+    {
+        if (OldState != QuestState.Any && NewState != QuestState.Completed && subQuest.State != OldState)
+            return false;
+
+        // A one-shot "give item" conversation event has no persistent state to re-check, so (unlike
+        // GlobalVariable/Item triggers) it must only complete the step that is currently active --
+        // otherwise handing the item over could complete a step that hasn't been reached yet.
+        if (subQuest.State != QuestState.Active)
+            return false;
+
+        if (@event is ConversationEvent e && e.Interaction == ConversationEvent.InteractionType.GiveItem && e.ItemIndex == itemIndex)
         {
             subQuest.State = NewState;
             return true;
@@ -1125,6 +1155,37 @@ partial class QuestLog
                     ],
                     SourceType = QuestSourceType.NPC,
                     SourceIndex = 17, // Sariel
+                }
+            ),
+            #endregion
+            #region Orcs
+            QuestFactory.CreateMainQuest(this, MainQuestType.OrcPlague,
+                mainQuest => new SubQuest(this, mainQuest)
+                {
+                    Type = SubQuestType.OrcPlague_DefeatTheOrcLeader,
+                    Triggers =
+                    [
+                        // Activate: Freiherr Georg (head of Spannenberg) tells about the two problems and teaches the keyword "Probleme"
+                        new KeywordLearnedTrigger(game, TriggerType.Activation, 23), // PROBLEME
+                        // Complete: obtained the hill giant's head (item 268), proof the orc leader is dead
+                        new ItemObtainedTrigger(game, TriggerType.Completion, 268), // KOPF HÜGELRIESEN
+                    ],
+                    SourceType = QuestSourceType.NPC,
+                    SourceIndex = 8, // Freiherr Georg von Spannenberg
+                },
+                mainQuest => new SubQuest(this, mainQuest)
+                {
+                    Type = SubQuestType.OrcPlague_ReturnToGeorg,
+                    Triggers =
+                    [
+                        // Activate: once the leader is defeated (head obtained)
+                        new PreviousSubQuestCompletedTrigger(),
+                        // Complete: hand the giant's head to Georg. The original game tracks this with no global variable,
+                        // so we observe the GiveItem conversation event. TODO: confirm in a playtest that this event reaches the quest log.
+                        new ItemGivenToNpcTrigger(TriggerType.Completion, 268), // KOPF HÜGELRIESEN
+                    ],
+                    SourceType = QuestSourceType.NPC,
+                    SourceIndex = 8, // Freiherr Georg von Spannenberg
                 }
             ),
             #endregion

--- a/Ambermoon.Core/UI/Quests.cs
+++ b/Ambermoon.Core/UI/Quests.cs
@@ -264,34 +264,6 @@ file class GlobalVariableTrigger(Game game, TriggerType triggerType, uint index,
     }
 }
 
-// Fires when the party hands a specific item to an NPC during a conversation (a "GiveItem" interaction).
-// Used for "return the proof to the quest giver" steps that the original game does NOT track with a global variable.
-file class ItemGivenToNpcTrigger(TriggerType triggerType, uint itemIndex) : IQuestTrigger
-{
-    public QuestState OldState => triggerType.GetOldState();
-    public QuestState NewState => triggerType.GetNewState();
-
-    bool IQuestTrigger.CheckEvent(Event @event, SubQuest subQuest)
-    {
-        if (OldState != QuestState.Any && NewState != QuestState.Completed && subQuest.State != OldState)
-            return false;
-
-        // A one-shot "give item" conversation event has no persistent state to re-check, so (unlike
-        // GlobalVariable/Item triggers) it must only complete the step that is currently active --
-        // otherwise handing the item over could complete a step that hasn't been reached yet.
-        if (subQuest.State != QuestState.Active)
-            return false;
-
-        if (@event is ConversationEvent e && e.Interaction == ConversationEvent.InteractionType.GiveItem && e.ItemIndex == itemIndex)
-        {
-            subQuest.State = NewState;
-            return true;
-        }
-
-        return false;
-    }
-}
-
 file class TileChangeTrigger(Game game, TriggerType triggerType, uint mapIndex, uint x, uint y, uint expectedTile) : IQuestTrigger
 {
     public QuestState OldState => triggerType.GetOldState();
@@ -1167,8 +1139,13 @@ partial class QuestLog
                     [
                         // Activate: Freiherr Georg (head of Spannenberg) tells about the two problems and teaches the keyword "Probleme"
                         new KeywordLearnedTrigger(game, TriggerType.Activation, 23), // PROBLEME
-                        // Complete: obtained the hill giant's head (item 268), proof the orc leader is dead
-                        new ItemObtainedTrigger(game, TriggerType.Completion, 268), // KOPF HÜGELRIESEN
+                        // Complete: obtained the hill giant's head (item 268, proof the orc leader is dead),
+                        // OR the head was already handed to Baron George (the custom global variable below).
+                        // The latter is needed so this step stays completed after a save/reload, when the head
+                        // is no longer in the inventory (ItemObtainedTrigger only checks items you currently own).
+                        new OrTrigger<ItemObtainedTrigger, GlobalVariableTrigger>(game, TriggerType.Completion,
+                            (g, t) => new ItemObtainedTrigger(g, t, 268), // KOPF HÜGELRIESEN
+                            (g, t) => new GlobalVariableTrigger(g, t, GlobalVar_GaveOrcLeaderHeadToBaronGeorge)),
                     ],
                     SourceType = QuestSourceType.NPC,
                     SourceIndex = 8, // Freiherr Georg von Spannenberg
@@ -1180,9 +1157,10 @@ partial class QuestLog
                     [
                         // Activate: once the leader is defeated (head obtained)
                         new PreviousSubQuestCompletedTrigger(),
-                        // Complete: hand the giant's head to Georg. The original game tracks this with no global variable,
-                        // so we observe the GiveItem conversation event. TODO: confirm in a playtest that this event reaches the quest log.
-                        new ItemGivenToNpcTrigger(TriggerType.Completion, 268), // KOPF HÜGELRIESEN
+                        // Complete: hand the giant's head to Baron George. The original game changes nothing in the
+                        // savegame here, so a custom global variable is set on that GiveItem event (see
+                        // QuestCustomVariables) and checked here -- this persists the progress across a save/reload.
+                        new GlobalVariableTrigger(game, TriggerType.Completion, GlobalVar_GaveOrcLeaderHeadToBaronGeorge),
                     ],
                     SourceType = QuestSourceType.NPC,
                     SourceIndex = 8, // Freiherr Georg von Spannenberg


### PR DESCRIPTION
Proof of concept of adding new quests based on quests branch (since I am waiting for the quest log to play :))

Defeat the orc leader for Georg and bring back the proof (the hill giant's head).

Adds an ItemGivenToNpcTrigger so a step can complete when an item is handed to an NPC in a conversation (game does not track with a global variable).

EDIT: not sure why appveyor fails